### PR TITLE
Correction to allow change in inner element and insert after parent

### DIFF
--- a/TypeScriptAST/Change/ChangeAST.cs
+++ b/TypeScriptAST/Change/ChangeAST.cs
@@ -17,7 +17,7 @@ namespace Zu.TypeScript.Change
 
         public static string Change(string source, IEnumerable<NodeChangeItem> changeItems)
         {
-            var changes = changeItems.OrderBy(v => v.Node.Pos).ThenBy(v2 => v2.ChangeType);
+            var changes = changeItems.OrderBy(v => v.Node.End).ThenBy(v2 => v2.ChangeType);
             var sb = new StringBuilder();
             var pos = 0;
             foreach (var ch in changes)


### PR DESCRIPTION
Hi,

This correction allows us to have a change in an inner element and insert after father. Ex: Assuming this element
          {
            path: 'AlteracaoContrato/:alteracaoContratualId/:contratoId', data: { breadcrumb: { label: 'Lea.AlteracoesContratuais.PageTitles.Details' } as Breadcrumb },
            children: ...,
          },
With this change I can perform changes do prop assignment: data: { breadcrumb: { label: 'Lea.AlteracoesContratuais.PageTitles.Details' } as Breadcrumb } and insert another routing element after, like:
          {
            path: 'addedElement', data: ...,
            children: ...,
          },
.
With previous implementation text would be broken.
